### PR TITLE
Display error type and location in the test failure message

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,8 +73,8 @@ Running it again with `RUST_BACKTRACE=1 cargo test` shows more details:
 
 ```text
 ---- tests::it_works stdout ----
-thread 'tests::it_works' panicked at 'Error: No such file or directory (os error 2)', src/lib.rs:10:9
-  ...
+thread 'tests::it_works' panicked at 'error: std::io::error::Error - No such file or directory (os error 2)', src/lib.rs:53:9
+  ...                                                                                                              ^^^^^^^^^^^^^^^
    3: <core::result::Result<T,F> as core::ops::try_trait::FromResidual<core::result::Result<core::convert::Infallible,E>>>::from_residual
              at /rustc/4b91a6ea7258a947e59c6522cd5898e7c0a6a88f/library/core/src/result.rs:2125:27
    4: testresult::tests::it_works
@@ -87,7 +87,10 @@ thread 'tests::it_works' panicked at 'Error: No such file or directory (os error
 note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
 ```
 
+Note that the error location is now in the backtrace and also in the test failure message. This means that we don't
+even need the backtrace to know where the error happened.
+
 The advantages of using `TestResult`:
-  - exact failure line is present in the backtrace,
-  - the underlying error message is present in the test failure,
+  - exact failure line is present in the test failure and the backtrace,
+  - the underlying error type and message are present in the test failure,
   - the signature of the test result is simpler.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,20 +7,15 @@
 /// Any other type of error can be converted to this one but the
 /// conversion will always panic.
 ///
-/// This type is useful only in unit tests.
+/// This type is useful only in the result of unit tests and cannot be instantiated.
 #[derive(Debug)]
 #[doc(hidden)]
-pub struct ErrorWithStacktrace;
+pub enum ErrorWithStacktrace {}
 
-impl<T: std::error::Error> From<T> for ErrorWithStacktrace {
+impl<T: std::fmt::Display> From<T> for ErrorWithStacktrace {
+    #[track_caller] // Will show the location of the caller in test failure messages
     fn from(error: T) -> Self {
-        panic!("Error: {}", error);
-    }
-}
-
-impl std::fmt::Display for ErrorWithStacktrace {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "This is an error with stacktrace")
+        panic!("error: {} - {}", std::any::type_name::<T>(), error);
     }
 }
 
@@ -38,10 +33,10 @@ impl std::fmt::Display for ErrorWithStacktrace {
 ///
 /// #[test]
 /// fn it_works() -> TestResult {
-///   // ...
-///    std::fs::File::open("this-file-does-not-exist")?;
-///    // ...
-///    Ok(())
+///     // ...
+///     std::fs::File::open("this-file-does-not-exist")?;
+///     // ...
+///     Ok(())
 /// }
 /// ```
 
@@ -69,13 +64,6 @@ mod tests {
             let _ = test_fn();
         });
         assert!(result.is_err());
-        Ok(())
-    }
-
-    #[test]
-    fn text_prints() -> TestResult {
-        let text = format!("{}", ErrorWithStacktrace);
-        assert!(!text.is_empty());
         Ok(())
     }
 }


### PR DESCRIPTION
This PR provides a few improvements:
- adds `#[track_caller]` to `ErrorWithStacktrace::from()`. This allows the error location to be displayed in the test failure message, and not that of `from()`,
- adds the error type name to the test failure message,
- changes `From<T: Error>` to `From<T: Display>` to accept more error types, such as `anyhow::Error` that [doesn't implement `std::Error`](https://github.com/dtolnay/anyhow/issues/25).
- changes `ErrorWithStacktrace` to be an empty enum so that it cannot be instantiated (and consequently removed its `Display` implementation),
- changes `Error` to `error` in the test failure message, to be consistent with other failure messages.

I actually developed this exact same feature independently, even using the name `TestResult`! (see [blog post explaining it](https://bluxte.net/musings/2023/01/08/improving_failure_messages_rust_tests/)) and found this project when I considered publishing it to crates.io. This PR brings the differences of my implementation to `testresult` to make it even more useful!