### PR TITLE
Release version 0.2.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "testresult"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Wiktor Kwapisiewicz <wiktor@metacode.biz>"]
 description = "Provides TestResult type for concise and precise test failures"


### PR DESCRIPTION
Most changes are contained in PR #3.

The version number is 0.2.0 since a minor API change happened: `ErrorWithStacktrace` is now an enum instead of being a struct. It shouldn't affect user code in any way.