### PR TITLE
Expose testerror (and minor docs improvements)

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,7 @@ impl<T: std::fmt::Display> From<T> for TestError {
     }
 }
 
-/// Unit test result
+/// Unit test result - always panics when an error occurs
 ///
 /// This type allows panicking when encountering any type of
 /// failure. Thus it allows using the `?` operator in unit tests but still

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,12 +4,15 @@
 // the docs illustrate the usage in test functions
 #![allow(clippy::test_attr_in_doctest)]
 
-/// Error with a stacktrace
+/// Error, but one which immediately panics with a stacktrace
+///
+/// Usually used via [`TestResult`].
 ///
 /// Any other type of error can be converted to this one but the
 /// conversion will always panic.
 ///
-/// This type is useful only in unit tests and cannot be directly instantiated.
+/// This type is useful only in unit tests.
+/// It cannot be instantiated: no values of this type can ever exist.
 #[derive(Debug)]
 pub enum TestError {}
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,6 @@
 ///
 /// This type is useful only in unit tests and cannot be directly instantiated.
 #[derive(Debug)]
-#[doc(hidden)]
 pub enum TestError {}
 
 impl<T: std::fmt::Display> From<T> for TestError {


### PR DESCRIPTION
Closes #13

Apropos the discussion there, I think it's fine to expose that this is `enum {}`.  We probably don't want to change that - in particular, we aren't likely to want to make this an alias for something else, nor are we likely to need to make it an opaque `struct`.

(Incidentally, I have a similar type in one of my own projects: https://salsa.debian.org/iwj/otter/-/blob/main/apitest/apitest.rs?ref_type=heads#L109.  Mine is different to `TestError` because it displays error sources too, which is a different answer to the problem that `Display` is kind of broken for implementors of `std::error::Error`.)