### PR TITLE
Move lint suppression to library level

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,8 @@
 #![doc = include_str!("../README.md")]
 #![deny(missing_debug_implementations)]
 #![deny(missing_docs)]
+// the docs illustrate the usage in test functions
+#![allow(clippy::test_attr_in_doctest)]
 
 /// Error with a stacktrace
 ///
@@ -21,7 +23,6 @@ impl<T: std::fmt::Display> From<T> for TestError {
     }
 }
 
-#[allow(clippy::test_attr_in_doctest)] // the docs illustrate the usage in test functions
 /// Unit test result
 ///
 /// This type allows panicking when encountering any type of


### PR DESCRIPTION
New version of Rust complains about README.md included docs but since this library is about usage in tests these examples are perfectly fine.

This is causing problems in https://github.com/wiktor-k/testresult/pull/14.

@ijackson would you mind checking if this is good to merge?

If so the plan would be to merge this PR first, then rebase yours on top of `main` and I think we would be good to go.